### PR TITLE
feat: get OSD window handler by turn volume up/down

### DIFF
--- a/VolumeOsd.ahk
+++ b/VolumeOsd.ahk
@@ -25,6 +25,10 @@ class VolumeOsd
 
     Find()
     {
+        ; // turn volume up and down to show OSD on the screen and get handler generated
+        Send, {Volume_Up}
+        Send, {Volume_Down}
+
         result := 0
         count := 0
         parentHandle := 0


### PR DESCRIPTION
When windows first starts, the volume OSD handler may or may not exist. This is causing the script fail to find the volume OSD before hiding it.

By turn volume up/down first, the volume OSD handler is guaranteed to exist.

This PR is trying to implement [VolumeUp/Down](https://github.com/UnlimitedStack/HideVolumeOSD/blob/master/HideVolumeOSD/HideVolumeOSDLib.cs#L146-L147)in an ahk way.
